### PR TITLE
fix(node): exporting parseArrayBuffer for node.js

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,6 +3,11 @@ import { IMidiJsonParserWorkerCustomDefinition } from './interfaces';
 import { parseArrayBuffer } from './midi-file-parser';
 
 /*
+ * This export can provide Node.js support
+ */
+export { parseArrayBuffer } from './midi-file-parser';
+
+/*
  * @todo Explicitly referencing the barrel file seems to be necessary when enabling the
  * isolatedModules compiler option.
  */


### PR DESCRIPTION
- this export allows node.js to import the `parseArrayBuffer` file
  directly
- ideally, the `import` in node.js is coming from the root `module.js`
  file, but the side-effects that are present in the file prevent that.